### PR TITLE
Add support for reading floating point formats (Java Runtime)

### DIFF
--- a/src/main/java/io/kaitai/struct/KaitaiStream.java
+++ b/src/main/java/io/kaitai/struct/KaitaiStream.java
@@ -24,6 +24,8 @@
 package io.kaitai.struct;
 
 import java.io.*;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 import java.nio.charset.Charset;
 import java.util.Arrays;
 import java.util.zip.DataFormatException;
@@ -79,6 +81,14 @@ public class KaitaiStream {
      */
     public boolean isEof() throws IOException {
         return st.isEof();
+    }
+
+    private ByteBuffer wrapBufferLe(int count) throws IOException {
+        return ByteBuffer.wrap(readBytes(count)).order(ByteOrder.LITTLE_ENDIAN);
+    }
+
+    private ByteBuffer wrapBufferBe(int count) throws IOException {
+        return ByteBuffer.wrap(readBytes(count)).order(ByteOrder.BIG_ENDIAN);
     }
 
     /**
@@ -210,6 +220,22 @@ public class KaitaiStream {
         long b1 = readU4be();
         long b2 = readU4be();
         return (b1 << 32) + (b2 << 0);
+    }
+
+    public float readF4le() throws IOException {
+        return wrapBufferLe(4).getFloat();
+    }
+
+    public double readF8le() throws IOException {
+        return wrapBufferLe(8).getDouble();
+    }
+
+    public float readF4be() throws IOException {
+        return wrapBufferBe(4).getFloat();
+    }
+
+    public double readF8be() throws IOException {
+        return wrapBufferBe(8).getDouble();
     }
 
     public byte[] readBytes(long n) throws IOException {


### PR DESCRIPTION
I found Java's `ByteBuffer` class which supports converting byte arrays into float/double - it looks like it's got native support for short/int/long as well. Should we change all the `readS` methods to use the `ByteBuffer` class? Seems more maintainable than the hand-coded method. There's no built-in methods to deal with unsigned types so the `readU` methods will still need to be manual.
