### PR TITLE
Invalid HTML for javadoc created and Maven printed an error saying that.

### DIFF
--- a/src/main/java/io/kaitai/struct/KaitaiStream.java
+++ b/src/main/java/io/kaitai/struct/KaitaiStream.java
@@ -559,7 +559,7 @@ public class KaitaiStream {
      * greater than [0x10].
      * @param a first byte array to compare
      * @param b second byte array to compare
-     * @return negative number if a < b, 0 if a == b, positive number if a > b
+     * @return negative number if a &lt; b, 0 if a == b, positive number if a &gt; b
      * @see Comparable#compareTo(Object)
      */
     public static int byteArrayCompare(byte[] a, byte[] b) {


### PR DESCRIPTION
     [exec] [ERROR] Failed to execute goal org.apache.maven.plugins:maven-javadoc-plugin:2.9.1:jar (attach-javadocs) on project kaitai-struct-runtime: MavenReportException: Error while creating archive:
     [exec] [ERROR] Exit code: 1 - C:\Users\tschoening\Documents\Eclipse\Java Bug 2373\Libs Java 3rd\Parsers\Generators\kaitai_struct\runtime\master\src\src\main\java\io\kaitai\struct\KaitaiStream.java:562: error: malformed HTML
     [exec] [ERROR] * @return negative number if a < b, 0 if a == b, positive number if a > b
     [exec] [ERROR] ^
     [exec] [ERROR] C:\Users\tschoening\Documents\Eclipse\Java Bug 2373\Libs Java 3rd\Parsers\Generators\kaitai_struct\runtime\master\src\src\main\java\io\kaitai\struct\KaitaiStream.java:562: error: bad use of '>'
     [exec] [ERROR] * @return negative number if a < b, 0 if a == b, positive number if a > b
     [exec] [ERROR] ^
     [exec] [ERROR] 
     [exec] [ERROR] Command line was: "C:\Program Files\Java\jdk1.8\jre\..\bin\javadoc.exe" @options @packages
     [exec] [ERROR] 
     [exec] [ERROR] Refer to the generated Javadoc files in 'C:\Users\tschoening\Documents\Eclipse\Java Bug 2373\Libs Java 3rd\Parsers\Generators\kaitai_struct\runtime\master\src\target\apidocs' dir.
     [exec] [ERROR] -> [Help 1]
     [exec] [ERROR] 
     [exec] [ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
     [exec] [ERROR] Re-run Maven using the -X switch to enable full debug logging.
     [exec] [ERROR] 
     [exec] [ERROR] For more information about the errors and possible solutions, please read the following articles:
     [exec] [ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoExecutionException