### PR TITLE
Add ByteBuffer Constructor

### DIFF
--- a/src/main/java/io/kaitai/struct/KaitaiStream.java
+++ b/src/main/java/io/kaitai/struct/KaitaiStream.java
@@ -80,6 +80,15 @@ public class KaitaiStream {
     }
 
     /**
+     * Initializes a stream that will get data from given ByteBuffer when read.
+     * @param buffer ByteBuffer to read
+     */
+    public KaitaiStream(ByteBuffer buffer) {
+        fc = null;
+        bb = buffer;
+    }
+
+    /**
      * Provide a read-only version of the {@link ByteBuffer} backing the data of this instance.
      * <p>
      * This way one can access the underlying raw bytes associated with this structure, but it is


### PR DESCRIPTION
I think adding a straight ByteBuffer constructor makes some scenarios easier. If the source file is compressed, requiring a byte array means decompressing the entire file into memory first.