### PR TITLE
Removed an unnecessary whitespace which maked the exception message look

### DIFF
--- a/src/main/java/io/kaitai/struct/KaitaiStream.java
+++ b/src/main/java/io/kaitai/struct/KaitaiStream.java
@@ -601,7 +601,7 @@ public class KaitaiStream {
         public UnexpectedDataError(byte[] actual, byte[] expected) {
             super(
                     "Unexpected fixed contents: got " + byteArrayToHex(actual) +
-                    " , was waiting for " + byteArrayToHex(expected)
+                    ", was waiting for " + byteArrayToHex(expected)
             );
         }
 


### PR DESCRIPTION
a bit odd:

> Unexpected fixed contents: got 70 , was waiting for 78
vs.
> Unexpected fixed contents: got 70, was waiting for 78