### PR TITLE
Fix mvn build javadoc errors

### DIFF
--- a/src/main/java/io/kaitai/struct/KaitaiStream.java
+++ b/src/main/java/io/kaitai/struct/KaitaiStream.java
@@ -57,10 +57,7 @@ public abstract class KaitaiStream implements Closeable {
     protected int bitsLeft = 0;
     protected long bits = 0;
 
-    /**
-     * Closes the stream safely - i.e. closes the files, network connections, etc, if needed.
-     * @throws IOException
-     */
+    @Override
     abstract public void close() throws IOException;
 
     //region Stream positioning

--- a/src/main/java/io/kaitai/struct/RandomAccessFileKaitaiStream.java
+++ b/src/main/java/io/kaitai/struct/RandomAccessFileKaitaiStream.java
@@ -11,13 +11,13 @@ import java.nio.ByteOrder;
  * An implementation of {@link KaitaiStream} backed by a {@link RandomAccessFile}.
  *
  * Allows reading from local files. Generally, one would want to use
- * {@link ByteBufferKaitaiStream} instead, as it is most likely would be faster,
- * but there are two situation when one should consider this one instead:
+ * {@link ByteBufferKaitaiStream} instead, as it most likely would be faster,
+ * but there are two situations when one should consider this one instead:
  *
  * <ul>
  * <li>Processing many small files. Every ByteBuffer invocation requires a mmap
  * call, which can be relatively expensive (per file).</li>
- * <li>Accessing extra-long files (>31 bits positioning). Unfortunately, Java's
+ * <li>Accessing extra-long files (&gt;31 bits positioning). Unfortunately, Java's
  * implementation of mmap uses ByteBuffer, which is not addressable beyond 31 bit
  * offsets, even if you use a 64-bit platform.</li>
  * </ul>
@@ -263,7 +263,7 @@ public class RandomAccessFileKaitaiStream extends KaitaiStream {
     public double readF8be() {
         return wrapBufferBe(8).getDouble();
     }
-    
+
     //endregion
 
     //region Little-endian


### PR DESCRIPTION
Building the runtime using Maven with default settings that worked in the past before 0.8 leads to a build failure because of minor errors in JavaDoc now. I fixed those in this PR in addition to what I believe are minor spelling errors, because they were in the same comment.

I wasn't sure about how to properly deal with `close`, but in my opinion removing the comment is the easiest to do, as it doesn't add too much value.

        [exec] [INFO] ------------------------------------------------------------------------
        [exec] [INFO] BUILD FAILURE
        [exec] [INFO] ------------------------------------------------------------------------
        [exec] [INFO] Total time: 3.532 s
        [exec] [INFO] Finished at: 2018-02-14T19:13:49+01:00
        [exec] [INFO] Final Memory: 25M/503M
        [exec] [INFO] ------------------------------------------------------------------------
        [exec] [ERROR] Failed to execute goal org.apache.maven.plugins:maven-javadoc-plugin:2.9.1:jar (attach-javadocs) on project kaitai-struct-runtime: MavenReportException: Error while creating archive:
        [exec] [ERROR] Exit code: 1 - C:\Users\tschoening\Documents\Eclipse\Java Sm-Mtg Bug 2461\Libs Java 3rd\Parsers\Generators\kaitai_struct\runtime\master\src\src\main\java\io\kaitai\struct\KaitaiStream.java:62: warning: no description for @throws
        [exec] [ERROR] * @throws IOException
        [exec] [ERROR] ^
        [exec] [ERROR] C:\Users\tschoening\Documents\Eclipse\Java Sm-Mtg Bug 2461\Libs Java 3rd\Parsers\Generators\kaitai_struct\runtime\master\src\src\main\java\io\kaitai\struct\RandomAccessFileKaitaiStream.java:20: error: bad use of '>'
        [exec] [ERROR] * <li>Accessing extra-long files (>31 bits positioning). Unfortunately, Java's
        [exec] [ERROR] ^
        [exec] [ERROR] 
        [exec] [ERROR] Command line was: "C:\Program Files\Java\jdk1.8\jre\..\bin\javadoc.exe" @options @packages
        [exec] [ERROR] 
        [exec] [ERROR] Refer to the generated Javadoc files in 'C:\Users\tschoening\Documents\Eclipse\Java Sm-Mtg Bug 2461\Libs Java 3rd\Parsers\Generators\kaitai_struct\runtime\master\src\target\apidocs' dir.
        [exec] [ERROR] -> [Help 1]
        [exec] [ERROR] 
        [exec] [ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
        [exec] [ERROR] Re-run Maven using the -X switch to enable full debug logging.
        [exec] [ERROR] 
        [exec] [ERROR] For more information about the errors and possible solutions, please read the following articles:
        [exec] [ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoExecutionException