### PR TITLE
Fixed Javadoc errors preventing "mvn package" from succeeding.

### DIFF
--- a/src/main/java/io/kaitai/struct/KaitaiStream.java
+++ b/src/main/java/io/kaitai/struct/KaitaiStream.java
@@ -221,7 +221,7 @@ public abstract class KaitaiStream implements Closeable {
     /**
      * Unused since Kaitai Struct Compiler v0.9+ - compatibility with older versions
      *
-     * @deprecated use {@link #readBitsIntBe()} instead
+     * @deprecated use {@link #readBitsIntBe(int)} instead
      */
     @Deprecated
     public long readBitsInt(int n) {

--- a/src/main/java/io/kaitai/struct/annotations/Generated.java
+++ b/src/main/java/io/kaitai/struct/annotations/Generated.java
@@ -56,6 +56,7 @@ public @interface Generated {
      * Class compiled with support of position tracking. That means, that every class
      * has following public fields (in that version of generator):
      * <table>
+     * <caption>Position tracking info.</caption>
      * <tr><th>Type</th><th>Field</th><th>Description</th></tr>
      * <tr><td>{@code Map<String, Integer>}</td><td>{@code _attrStart}</td>
      *     <td>Start offset in the root stream, where {@link SeqItem an attribute} or


### PR DESCRIPTION
        [exec] [ERROR] Failed to execute goal org.apache.maven.plugins:maven-javadoc-plugin:2.9.1:jar (attach-javadocs) on project kaitai-struct-runtime: MavenReportException: Error while creating archive:
        [exec] [ERROR] Exit code: 1 - C:\Users\tschoening\Documents\Eclipse\Java Sm-Mtg\Libs Java 3rd\Parsers\Generators\kaitai_struct\runtime\libs_java_3rd_usage\src\src\main\java\io\kaitai\struct\annotations\Generated.java:80: error: no summary or caption for table
        [exec] [ERROR]      * </table>
        [exec] [ERROR]        ^
        [exec] [ERROR] C:\Users\tschoening\Documents\Eclipse\Java Sm-Mtg\Libs Java 3rd\Parsers\Generators\kaitai_struct\runtime\libs_java_3rd_usage\src\src\main\java\io\kaitai\struct\KaitaiStream.java:224: error: reference not found
        [exec] [ERROR]      * @deprecated use {@link #readBitsIntBe()} instead