### PR TITLE
Update dependencies, add instructions to build and a GitHub Action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,22 @@
+name: CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-java@v2
+        with:
+          java-version: '17'
+          distribution: 'adopt'
+
+      - name: Run the Maven verify phase
+        run: mvn --batch-mode verify

--- a/README.md
+++ b/README.md
@@ -14,22 +14,15 @@ Further reading:
 * [About API implemented in this library](http://doc.kaitai.io/stream_api.html)
 * [Java-specific notes](http://doc.kaitai.io/lang_java.html)
 
-# Build
-To build library run the following command:
+## Build
+To build the library, run the following command:
 
-```console
+```sh
 mvn install
 ```
 
-# Release
-To make a release ensure that you have:
-
-- a [gpg](https://gnupg.org/) installed
-- a [configured](https://maven.apache.org/plugins/maven-gpg-plugin/usage.html) gpg signing key
-- pass `-DperformRelease=true` argument to the maven command invocation:
-
-  ```console
-  mvn -DperformRelease=true deploy
-  ```
-
-See also http://doc.kaitai.io/developers.html#java.
+## Release
+<sub>
+If you are maintainer of this project please visit http://doc.kaitai.io/developers.html#java
+to get instructions how to make a release.
+</sub>

--- a/README.md
+++ b/README.md
@@ -13,3 +13,23 @@ Further reading:
 * [About Kaitai Struct](http://kaitai.io/)
 * [About API implemented in this library](http://doc.kaitai.io/stream_api.html)
 * [Java-specific notes](http://doc.kaitai.io/lang_java.html)
+
+# Build
+To build library run the following command:
+
+```console
+mvn install
+```
+
+# Release
+To make a release ensure that you have:
+
+- a [gpg](https://gnupg.org/) installed
+- a [configured](https://maven.apache.org/plugins/maven-gpg-plugin/usage.html) gpg signing key
+- pass `-DperformRelease=true` argument to the maven command invocation:
+
+  ```console
+  mvn -DperformRelease=true deploy
+  ```
+
+See also http://doc.kaitai.io/developers.html#java.

--- a/pom.xml
+++ b/pom.xml
@@ -119,7 +119,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-gpg-plugin</artifactId>
-        <version>1.5</version>
+        <version>3.2.5</version>
         <executions>
           <execution>
             <id>sign-artifacts</id>

--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-source-plugin</artifactId>
-        <version>2.2.1</version>
+        <version>3.3.1</version>
         <executions>
           <execution>
             <id>attach-sources</id>

--- a/pom.xml
+++ b/pom.xml
@@ -79,7 +79,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>3.2.0</version>
+        <version>3.7.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>

--- a/pom.xml
+++ b/pom.xml
@@ -54,6 +54,33 @@
         <maven.compiler.release>7</maven.compiler.release>
       </properties>
     </profile>
+    <profile>
+      <id>release-sign-artifacts</id>
+      <activation>
+        <property>
+          <name>performRelease</name>
+          <value>true</value>
+        </property>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-gpg-plugin</artifactId>
+            <version>3.2.5</version>
+            <executions>
+              <execution>
+                <id>sign-artifacts</id>
+                <phase>verify</phase>
+                <goals>
+                  <goal>sign</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
   </profiles>
 
   <build>
@@ -115,20 +142,6 @@
             <tag><name>see</name></tag>
           </tags>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-gpg-plugin</artifactId>
-        <version>3.2.5</version>
-        <executions>
-          <execution>
-            <id>sign-artifacts</id>
-            <phase>verify</phase>
-            <goals>
-              <goal>sign</goal>
-            </goals>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>


### PR DESCRIPTION
To allow developers without gpg test their changes I moved signing under a flag. Now if you need to sign artefacts you should pass `-DperformRelease=true` flag to the maven command:

```console
mvn -DperformRelease=true deploy
```