### PR TITLE
Make the compiled package runnable on Java 7 or any later version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,10 +40,29 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <maven.compiler.source>1.7</maven.compiler.source>
+    <maven.compiler.target>1.7</maven.compiler.target>
   </properties>
+
+  <profiles>
+    <profile>
+      <id>jdk9</id>
+      <activation>
+        <jdk>[1.9,)</jdk>
+      </activation>
+      <properties>
+        <maven.compiler.release>7</maven.compiler.release>
+      </properties>
+    </profile>
+  </profiles>
 
   <build>
     <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.10.1</version>
+      </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-source-plugin</artifactId>
@@ -110,15 +129,6 @@
             </goals>
           </execution>
         </executions>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.1</version>
-        <configuration>
-          <source>6</source>
-          <target>6</target>
-        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/pom.xml
+++ b/pom.xml
@@ -79,7 +79,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.2.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>

--- a/src/main/java/io/kaitai/struct/ByteBufferKaitaiStream.java
+++ b/src/main/java/io/kaitai/struct/ByteBufferKaitaiStream.java
@@ -129,7 +129,7 @@ public class ByteBufferKaitaiStream extends KaitaiStream {
      * </p>
      * <p>
      * For more examples and suggestions, see:
-     * https://stackoverflow.com/questions/2972986/how-to-unmap-a-file-from-memory-mapped-using-filechannel-in-java
+     * <a href="https://stackoverflow.com/questions/2972986/how-to-unmap-a-file-from-memory-mapped-using-filechannel-in-java">How to unmap a file from memory mapped using FileChannel in java?</a>
      * </p>
      * @throws IOException if FileChannel can't be closed
      */

--- a/src/main/java/io/kaitai/struct/ByteBufferKaitaiStream.java
+++ b/src/main/java/io/kaitai/struct/ByteBufferKaitaiStream.java
@@ -129,7 +129,7 @@ public class ByteBufferKaitaiStream extends KaitaiStream {
      * </p>
      * <p>
      * For more examples and suggestions, see:
-     * <a href="https://stackoverflow.com/questions/2972986/how-to-unmap-a-file-from-memory-mapped-using-filechannel-in-java">How to unmap a file from memory mapped using FileChannel in java?</a>
+     * <a href="https://stackoverflow.com/q/2972986">How to unmap a file from memory mapped using FileChannel in java?</a>
      * </p>
      * @throws IOException if FileChannel can't be closed
      */

--- a/src/main/java/io/kaitai/struct/ByteBufferKaitaiStream.java
+++ b/src/main/java/io/kaitai/struct/ByteBufferKaitaiStream.java
@@ -106,8 +106,9 @@ public class ByteBufferKaitaiStream extends KaitaiStream {
     /**
      * Closes the stream safely. If there was an open file associated with it, closes that file.
      * For streams that were reading from in-memory array, does nothing.
+     * @implNote
      * <p>
-     * @implNote Unfortunately, there is no simple way to close memory-mapped ByteBuffer in
+     * Unfortunately, there is no simple way to close memory-mapped ByteBuffer in
      * Java and unmap underlying file. As {@link MappedByteBuffer} documentation suggests,
      * "mapped byte buffer and the file mapping that it represents remain valid until the
      * buffer itself is garbage-collected". Thus, the best we can do is to delete all


### PR DESCRIPTION
Fix #34

I checked that using the new `pom.xml`, the package compiled by `mvn package` is compatible with Java 7 and Java 8 (in particular, the problem reported in #34 no longer occurs) regardless of the Java version used for compilation, unlike the old `pom.xml` - here is the summary of test results performed in a [GitHub Actions workflow](https://github.com/generalmimon/ks-java-runtime-test/actions/runs/2576422290):

**Before** ([`generalmimon:set-jdk-7-in-pom-xml`](https://github.com/generalmimon/kaitai_struct_java_runtime/tree/set-jdk-7-in-pom-xml)):

| built on Java ╲ runs on Java | 7 | 8 | 11 | 17 | 18 |
| --- | - | - | - | - | - |
| 8  | [`✔️`][old-8-7]  | [`✔️`][old-8-8]  | [`✔️`][old-8-11]  | [`✔️`][old-8-17]  | [`✔️`][old-8-18]  |
| 11 | [`❌`][old-11-7] | [`❌`][old-11-8] | [`✔️`][old-11-11] | [`✔️`][old-11-17] | [`✔️`][old-11-18] |
| 17 | [`❌`][old-17-7] | [`❌`][old-17-8] | [`✔️`][old-17-11] | [`✔️`][old-17-17] | [`✔️`][old-17-18] |
| 18 | [`❌`][old-18-7] | [`❌`][old-18-8] | [`✔️`][old-18-11] | [`✔️`][old-18-17] | [`✔️`][old-18-18] |


**After** ([`kaitai-io:build-for-java-7`](https://github.com/kaitai-io/kaitai_struct_java_runtime/tree/build-for-java-7)):

| built on Java ╲ runs on Java | 7 | 8 | 11 | 17 | 18 |
| --- | - | - | - | - | - |
| 8  | [`✔️`][new-8-7]  | [`✔️`][new-8-8]  | [`✔️`][new-8-11]  | [`✔️`][new-8-17]  | [`✔️`][new-8-18]  |
| 11 | [`✔️`][new-11-7] | [`✔️`][new-11-8] | [`✔️`][new-11-11] | [`✔️`][new-11-17] | [`✔️`][new-11-18] |
| 17 | [`✔️`][new-17-7] | [`✔️`][new-17-8] | [`✔️`][new-17-11] | [`✔️`][new-17-17] | [`✔️`][new-17-18] |
| 18 | [`✔️`][new-18-7] | [`✔️`][new-18-8] | [`✔️`][new-18-11] | [`✔️`][new-18-17] | [`✔️`][new-18-18] |


[old-8-7]: https://github.com/generalmimon/ks-java-runtime-test/runs/7154879849?check_suite_focus=true "run (old, 8, 7)"
[old-8-8]: https://github.com/generalmimon/ks-java-runtime-test/runs/7154879955?check_suite_focus=true "run (old, 8, 8)"
[old-8-11]: https://github.com/generalmimon/ks-java-runtime-test/runs/7154880032?check_suite_focus=true "run (old, 8, 11)"
[old-8-17]: https://github.com/generalmimon/ks-java-runtime-test/runs/7154880095?check_suite_focus=true "run (old, 8, 17)"
[old-8-18]: https://github.com/generalmimon/ks-java-runtime-test/runs/7154880173?check_suite_focus=true "run (old, 8, 18)"
[old-11-7]: https://github.com/generalmimon/ks-java-runtime-test/runs/7154880277?check_suite_focus=true "run (old, 11, 7)"
[old-11-8]: https://github.com/generalmimon/ks-java-runtime-test/runs/7154880401?check_suite_focus=true "run (old, 11, 8)"
[old-11-11]: https://github.com/generalmimon/ks-java-runtime-test/runs/7154880571?check_suite_focus=true "run (old, 11, 11)"
[old-11-17]: https://github.com/generalmimon/ks-java-runtime-test/runs/7154880733?check_suite_focus=true "run (old, 11, 17)"
[old-11-18]: https://github.com/generalmimon/ks-java-runtime-test/runs/7154880889?check_suite_focus=true "run (old, 11, 18)"
[old-17-7]: https://github.com/generalmimon/ks-java-runtime-test/runs/7154881027?check_suite_focus=true "run (old, 17, 7)"
[old-17-8]: https://github.com/generalmimon/ks-java-runtime-test/runs/7154881164?check_suite_focus=true "run (old, 17, 8)"
[old-17-11]: https://github.com/generalmimon/ks-java-runtime-test/runs/7154881261?check_suite_focus=true "run (old, 17, 11)"
[old-17-17]: https://github.com/generalmimon/ks-java-runtime-test/runs/7154881360?check_suite_focus=true "run (old, 17, 17)"
[old-17-18]: https://github.com/generalmimon/ks-java-runtime-test/runs/7154881433?check_suite_focus=true "run (old, 17, 18)"
[old-18-7]: https://github.com/generalmimon/ks-java-runtime-test/runs/7154881514?check_suite_focus=true "run (old, 18, 7)"
[old-18-8]: https://github.com/generalmimon/ks-java-runtime-test/runs/7154881608?check_suite_focus=true "run (old, 18, 8)"
[old-18-11]: https://github.com/generalmimon/ks-java-runtime-test/runs/7154881693?check_suite_focus=true "run (old, 18, 11)"
[old-18-17]: https://github.com/generalmimon/ks-java-runtime-test/runs/7154881781?check_suite_focus=true "run (old, 18, 17)"
[old-18-18]: https://github.com/generalmimon/ks-java-runtime-test/runs/7154881897?check_suite_focus=true "run (old, 18, 18)"
[new-8-7]: https://github.com/generalmimon/ks-java-runtime-test/runs/7154881977?check_suite_focus=true "run (new, 8, 7)"
[new-8-8]: https://github.com/generalmimon/ks-java-runtime-test/runs/7154882058?check_suite_focus=true "run (new, 8, 8)"
[new-8-11]: https://github.com/generalmimon/ks-java-runtime-test/runs/7154882124?check_suite_focus=true "run (new, 8, 11)"
[new-8-17]: https://github.com/generalmimon/ks-java-runtime-test/runs/7154882197?check_suite_focus=true "run (new, 8, 17)"
[new-8-18]: https://github.com/generalmimon/ks-java-runtime-test/runs/7154882291?check_suite_focus=true "run (new, 8, 18)"
[new-11-7]: https://github.com/generalmimon/ks-java-runtime-test/runs/7154882439?check_suite_focus=true "run (new, 11, 7)"
[new-11-8]: https://github.com/generalmimon/ks-java-runtime-test/runs/7154882550?check_suite_focus=true "run (new, 11, 8)"
[new-11-11]: https://github.com/generalmimon/ks-java-runtime-test/runs/7154882677?check_suite_focus=true "run (new, 11, 11)"
[new-11-17]: https://github.com/generalmimon/ks-java-runtime-test/runs/7154882755?check_suite_focus=true "run (new, 11, 17)"
[new-11-18]: https://github.com/generalmimon/ks-java-runtime-test/runs/7154882851?check_suite_focus=true "run (new, 11, 18)"
[new-17-7]: https://github.com/generalmimon/ks-java-runtime-test/runs/7154882928?check_suite_focus=true "run (new, 17, 7)"
[new-17-8]: https://github.com/generalmimon/ks-java-runtime-test/runs/7154883008?check_suite_focus=true "run (new, 17, 8)"
[new-17-11]: https://github.com/generalmimon/ks-java-runtime-test/runs/7154883078?check_suite_focus=true "run (new, 17, 11)"
[new-17-17]: https://github.com/generalmimon/ks-java-runtime-test/runs/7154883145?check_suite_focus=true "run (new, 17, 17)"
[new-17-18]: https://github.com/generalmimon/ks-java-runtime-test/runs/7154883218?check_suite_focus=true "run (new, 17, 18)"
[new-18-7]: https://github.com/generalmimon/ks-java-runtime-test/runs/7154883312?check_suite_focus=true "run (new, 18, 7)"
[new-18-8]: https://github.com/generalmimon/ks-java-runtime-test/runs/7154883400?check_suite_focus=true "run (new, 18, 8)"
[new-18-11]: https://github.com/generalmimon/ks-java-runtime-test/runs/7154883486?check_suite_focus=true "run (new, 18, 11)"
[new-18-17]: https://github.com/generalmimon/ks-java-runtime-test/runs/7154883559?check_suite_focus=true "run (new, 18, 17)"
[new-18-18]: https://github.com/generalmimon/ks-java-runtime-test/runs/7154883640?check_suite_focus=true "run (new, 18, 18)"
