### PR TITLE
Fix possible underread when using `RandomAccessFileKaitaiStream`

### DIFF
--- a/src/main/java/io/kaitai/struct/RandomAccessFileKaitaiStream.java
+++ b/src/main/java/io/kaitai/struct/RandomAccessFileKaitaiStream.java
@@ -381,10 +381,7 @@ public class RandomAccessFileKaitaiStream extends KaitaiStream {
     protected byte[] readBytesNotAligned(long n) {
         byte[] buf = new byte[toByteArrayLength(n)];
         try {
-            int readCount = raf.read(buf);
-            if (readCount < n) {
-                throw new EOFException();
-            }
+            raf.readFully(buf);
             return buf;
         } catch (IOException e) {
             throw new RuntimeException(e);


### PR DESCRIPTION
[RandomAccessFile.read()](https://docs.oracle.com/javase/7/docs/api/java/io/RandomAccessFile.html#read(byte[])) can read fewer bytes than requested, this is not an EOF. -1 will be returned in case of EOF.