### PR TITLE
GHA: bump Java to 25 (was 21)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           distribution: 'temurin'
-          java-version: '21'
+          java-version: '25'
 
       - name: Get version from POM
         id: version
@@ -37,7 +37,7 @@ jobs:
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           distribution: 'temurin'
-          java-version: '21'
+          java-version: '25'
           server-id: central
           server-username: CENTRAL_SONATYPE_USERNAME
           server-password: CENTRAL_SONATYPE_PASSWORD
@@ -49,7 +49,7 @@ jobs:
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           distribution: 'temurin'
-          java-version: '21'
+          java-version: '25'
           server-id: central
           server-username: CENTRAL_SONATYPE_USERNAME
           server-password: CENTRAL_SONATYPE_PASSWORD


### PR DESCRIPTION
Java 25 is currently the latest LTS version. It was released over 6 months ago (see https://endoflife.date/oracle-jdk), so there has been enough time for the tooling to adapt to the breaking changes.